### PR TITLE
remove old queryset testing

### DIFF
--- a/django_admin_smoke_tests/tests.py
+++ b/django_admin_smoke_tests/tests.py
@@ -163,8 +163,6 @@ class AdminSiteSmokeTestMixin(object):
 
         # TODO: use model_mommy to generate a few instances to query against
         # make sure no errors happen here
-        if hasattr(model_admin, 'queryset'):
-            list(model_admin.queryset(request))
         if hasattr(model_admin, 'get_queryset'):
             list(model_admin.get_queryset(request))
 


### PR DESCRIPTION
since Django<1.8 support was dropped, so this is not tested anymore
it breaks tests when queryset method is defined on modeladmin for compatibility reasons
