### PR TITLE
Compatibility fixes for Django 1.10 compatibility, stronger tests, exclude_modeladmins option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - DJANGO_VERSION=dj17
   - DJANGO_VERSION=dj18
   - DJANGO_VERSION=dj19
+  - DJANGO_VERSION=dj110
   - DJANGO_VERSION=djdev
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
   include:
     - python: "2.7"
       env: MODE=flake8
+    - python: "3.4"
+      env: DJANGO_VERSION=dj17
 
 cache:
   directories:

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,7 @@ you can do following:
     class AdminSiteSmokeTest(AdminSiteSmokeTestMixin, TestCase):
         fixtures = ['data']
 
-And you can exclude certain (external) apps with::
+And you can exclude certain (external) apps or model admins with::
 
     exclude_apps = ['constance',]
+    exclude_modeladmins = [apps.admin.ModelAdmin]

--- a/django_admin_smoke_tests/tests.py
+++ b/django_admin_smoke_tests/tests.py
@@ -4,6 +4,7 @@ from django.contrib import admin, auth
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.test import TestCase
 from django.test.client import RequestFactory
+import django
 import sys
 
 
@@ -183,6 +184,8 @@ class AdminSiteSmokeTestMixin(object):
 
         # make sure no errors happen here
         response = model_admin.changelist_view(request)
+        response.render()
+
         self.assertEqual(response.status_code, 200)
 
     @for_all_model_admins
@@ -192,6 +195,27 @@ class AdminSiteSmokeTestMixin(object):
         # make sure no errors happen here
         try:
             response = model_admin.add_view(request)
+            if response.__class__ == django.template.response.TemplateResponse:
+                response.render()
+            self.assertEqual(response.status_code, 200)
+        except PermissionDenied:
+            # this error is commonly raised by ModelAdmins that don't allow
+            # adding.
+            pass
+
+    @for_all_model_admins
+    def test_change_view(self, model, model_admin):
+        item = model.objects.last()
+        if not item or model._meta.proxy:
+            return
+        pk = item.pk
+        request = self.get_request()
+
+        # make sure no errors happen here
+        try:
+            response = model_admin.change_view(request, object_id=str(pk))
+            if response.__class__ == django.template.response.TemplateResponse:
+                response.render()
             self.assertEqual(response.status_code, 200)
         except PermissionDenied:
             # this error is commonly raised by ModelAdmins that don't allow

--- a/django_admin_smoke_tests/tests.py
+++ b/django_admin_smoke_tests/tests.py
@@ -9,6 +9,12 @@ import django
 import sys
 
 
+class ModelAdminCheckException(Exception):
+    def __init__(self, message, original_exception):
+        super().__init__(message)
+        self.original_exception = original_exception
+
+
 def for_all_model_admins(fn):
     def test_deco(self):
         for model, model_admin in self.modeladmins:
@@ -18,11 +24,12 @@ def for_all_model_admins(fn):
                 continue
             try:
                 fn(self, model, model_admin)
-            except Exception:
-                raise Exception(
-                    "Above exception occured while running test '%s'"
+            except Exception as e:
+                raise ModelAdminCheckException(
+                    "Above exception occured while running test '%s' "
                     "on modeladmin %s (%s)" %
-                    (fn.__name__, model_admin, model.__name__)).\
+                    (fn.__name__, model_admin, model.__name__),
+                    e).\
                     with_traceback(sys.exc_info()[2])
     return test_deco
 

--- a/django_admin_smoke_tests/tests.py
+++ b/django_admin_smoke_tests/tests.py
@@ -86,10 +86,7 @@ class AdminSiteSmokeTestMixin(object):
 
     def get_fieldsets(self, model, model_admin):
         request = self.get_request()
-        try:
-            return model_admin.get_fieldsets(request, obj=model())
-        except AttributeError:
-            return model_admin.declared_fieldsets
+        return model_admin.get_fieldsets(request, obj=model())
 
     def get_attr_set(self, model, model_admin):
         attr_set = []

--- a/django_admin_smoke_tests/tests.py
+++ b/django_admin_smoke_tests/tests.py
@@ -163,8 +163,6 @@ class AdminSiteSmokeTestMixin(object):
 
         # TODO: use model_mommy to generate a few instances to query against
         # make sure no errors happen here
-        if hasattr(model_admin, 'queryset'):
-            list(model_admin.queryset(request))
         if hasattr(model_admin, 'get_queryset'):
             list(model_admin.get_queryset(request))
 

--- a/django_admin_smoke_tests/tests.py
+++ b/django_admin_smoke_tests/tests.py
@@ -2,6 +2,7 @@ import six
 
 from django.contrib import admin, auth
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
+from django.http.request import QueryDict
 from django.test import TestCase
 from django.test.client import RequestFactory
 import django
@@ -67,8 +68,9 @@ class AdminSiteSmokeTestMixin(object):
         except:
             pass
 
-    def get_request(self):
-        request = self.factory.get('/')
+    def get_request(self, params=None):
+        request = self.factory.get('/', params)
+
         request.user = self.superuser
         return request
 
@@ -184,6 +186,16 @@ class AdminSiteSmokeTestMixin(object):
     @for_all_model_admins
     def test_changelist_view(self, model, model_admin):
         request = self.get_request()
+
+        # make sure no errors happen here
+        response = model_admin.changelist_view(request)
+        response.render()
+
+        self.assertEqual(response.status_code, 200)
+
+    @for_all_model_admins
+    def test_changelist_view_search(self, model, model_admin):
+        request = self.get_request(params=QueryDict('q=test'))
 
         # make sure no errors happen here
         response = model_admin.changelist_view(request)

--- a/django_admin_smoke_tests/tests.py
+++ b/django_admin_smoke_tests/tests.py
@@ -6,13 +6,12 @@ from django.http.request import QueryDict
 from django.test import TestCase
 from django.test.client import RequestFactory
 import django
-import sys
 
 
 class ModelAdminCheckException(Exception):
     def __init__(self, message, original_exception):
-        super().__init__(message)
         self.original_exception = original_exception
+        return super(ModelAdminCheckException, self).__init__(message)
 
 
 def for_all_model_admins(fn):
@@ -25,12 +24,11 @@ def for_all_model_admins(fn):
             try:
                 fn(self, model, model_admin)
             except Exception as e:
-                raise ModelAdminCheckException(
+                six.raise_from(ModelAdminCheckException(
                     "Above exception occured while running test '%s' "
                     "on modeladmin %s (%s)" %
                     (fn.__name__, model_admin, model.__name__),
-                    e).\
-                    with_traceback(sys.exc_info()[2])
+                    e), e)
     return test_deco
 
 

--- a/django_admin_smoke_tests/tests.py
+++ b/django_admin_smoke_tests/tests.py
@@ -190,20 +190,28 @@ class AdminSiteSmokeTestMixin(object):
         request = self.get_request()
 
         # make sure no errors happen here
-        response = model_admin.changelist_view(request)
-        response.render()
-
-        self.assertEqual(response.status_code, 200)
+        try:
+            response = model_admin.changelist_view(request)
+            response.render()
+            self.assertEqual(response.status_code, 200)
+        except PermissionDenied:
+            # this error is commonly raised by ModelAdmins that don't allow
+            # changelist view
+            pass
 
     @for_all_model_admins
     def test_changelist_view_search(self, model, model_admin):
         request = self.get_request(params=QueryDict('q=test'))
 
         # make sure no errors happen here
-        response = model_admin.changelist_view(request)
-        response.render()
-
-        self.assertEqual(response.status_code, 200)
+        try:
+            response = model_admin.changelist_view(request)
+            response.render()
+            self.assertEqual(response.status_code, 200)
+        except PermissionDenied:
+            # this error is commonly raised by ModelAdmins that don't allow
+            # changelist view.
+            pass
 
     @for_all_model_admins
     def test_add_view(self, model, model_admin):
@@ -229,15 +237,10 @@ class AdminSiteSmokeTestMixin(object):
         request = self.get_request()
 
         # make sure no errors happen here
-        try:
-            response = model_admin.change_view(request, object_id=str(pk))
-            if response.__class__ == django.template.response.TemplateResponse:
-                response.render()
-            self.assertEqual(response.status_code, 200)
-        except PermissionDenied:
-            # this error is commonly raised by ModelAdmins that don't allow
-            # adding.
-            pass
+        response = model_admin.change_view(request, object_id=str(pk))
+        if response.__class__ == django.template.response.TemplateResponse:
+            response.render()
+        self.assertEqual(response.status_code, 200)
 
 
 class AdminSiteSmokeTest(AdminSiteSmokeTestMixin, TestCase):

--- a/django_admin_smoke_tests/tests.py
+++ b/django_admin_smoke_tests/tests.py
@@ -11,6 +11,8 @@ import sys
 def for_all_model_admins(fn):
     def test_deco(self):
         for model, model_admin in self.modeladmins:
+            if model_admin.__class__ in self.exclude_modeladmins:
+                continue
             if model._meta.app_label in self.exclude_apps:
                 continue
             try:
@@ -27,6 +29,7 @@ def for_all_model_admins(fn):
 class AdminSiteSmokeTestMixin(object):
     modeladmins = None
     exclude_apps = []
+    exclude_modeladmins = []
     fixtures = ['django_admin_smoke_tests']
 
     single_attributes = ['date_hierarchy']

--- a/django_admin_smoke_tests/tests.py
+++ b/django_admin_smoke_tests/tests.py
@@ -1,11 +1,12 @@
-import six
+import django
 
 from django.contrib import admin, auth
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.http.request import QueryDict
 from django.test import TestCase
 from django.test.client import RequestFactory
-import django
+
+import six
 
 
 class ModelAdminCheckException(Exception):

--- a/django_admin_smoke_tests/tests.py
+++ b/django_admin_smoke_tests/tests.py
@@ -221,7 +221,7 @@ class AdminSiteSmokeTestMixin(object):
         # make sure no errors happen here
         try:
             response = model_admin.add_view(request)
-            if response.__class__ == django.template.response.TemplateResponse:
+            if isinstance(response, django.template.response.TemplateResponse):
                 response.render()
             self.assertEqual(response.status_code, 200)
         except PermissionDenied:
@@ -239,7 +239,7 @@ class AdminSiteSmokeTestMixin(object):
 
         # make sure no errors happen here
         response = model_admin.change_view(request, object_id=str(pk))
-        if response.__class__ == django.template.response.TemplateResponse:
+        if isinstance(response, django.template.response.TemplateResponse):
             response.render()
         self.assertEqual(response.status_code, 200)
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from setuptools import setup
 import django_admin_smoke_tests
+
+from setuptools import setup
 
 package_name = 'django_admin_smoke_tests'
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def runtests():
     os.environ['DJANGO_SETTINGS_MODULE'] = 'test_project.settings'
     if django.VERSION[0] == 1 and django.VERSION[1] >= 7:
         django.setup()
-    call_command('test', 'django_admin_smoke_tests')
+    call_command('test', 'test_project.main.tests')
     sys.exit()
 
 setup(name='django-admin-smoke-tests',

--- a/test_project/main/admin.py
+++ b/test_project/main/admin.py
@@ -1,11 +1,12 @@
 # Django imports
-from django.contrib import admin
-from django.contrib.admin import SimpleListFilter
 import django
 
+from django.contrib import admin
+from django.contrib.admin import SimpleListFilter
+
 # App imports
-from .models import Channel, HasPrimarySlug, HasPrimaryUUID,\
-    Post, FailPost, ForbiddenPost
+from .models import Channel, FailPost, ForbiddenPost,\
+    HasPrimarySlug, HasPrimaryUUID, Post
 
 
 class ChannelAdmin(admin.ModelAdmin):

--- a/test_project/main/admin.py
+++ b/test_project/main/admin.py
@@ -18,6 +18,10 @@ class ListFilter(SimpleListFilter):
     title = "list_filter"
     parameter_name = "list_filter"
 
+    def __init__(self, request, params, model, model_admin):
+        super(ListFilter, self).__init__(request, params, model, model_admin)
+        self.lookup_val = request.GET.getlist('a')
+
     def lookups(self, request, model_admin):
         return ()
 

--- a/test_project/main/admin.py
+++ b/test_project/main/admin.py
@@ -1,6 +1,7 @@
 # Django imports
 from django.contrib import admin
 from django.contrib.admin import SimpleListFilter
+import django
 
 # App imports
 from .models import Channel, HasPrimarySlug, HasPrimaryUUID,\
@@ -48,7 +49,9 @@ class PostAdmin(admin.ModelAdmin):
 
 class FailPostAdmin(admin.ModelAdmin):
     search_fields = ['nonexistent_field']
-    list_display = ['nonexistent_field']
+
+    if django.VERSION >= (1, 8):
+        list_display = ['nonexistent_field']
 
 
 class ForbiddenPostAdmin(admin.ModelAdmin):

--- a/test_project/main/admin.py
+++ b/test_project/main/admin.py
@@ -1,8 +1,10 @@
 # Django imports
 from django.contrib import admin
+from django.contrib.admin import SimpleListFilter
 
 # App imports
-from .models import Channel, HasPrimarySlug, HasPrimaryUUID, Post
+from .models import Channel, HasPrimarySlug, HasPrimaryUUID,\
+    Post, FailPost, ForbiddenPost
 
 
 class ChannelAdmin(admin.ModelAdmin):
@@ -11,14 +13,29 @@ class ChannelAdmin(admin.ModelAdmin):
 admin.site.register(Channel, ChannelAdmin)
 
 
+class ListFilter(SimpleListFilter):
+    title = "list_filter"
+    parameter_name = "list_filter"
+
+    def lookups(self, request, model_admin):
+        return ()
+
+    def queryset(self, request, queryset):
+        return queryset
+
+
 class PostAdmin(admin.ModelAdmin):
     prepopulated_fields = {"slug": ("title",)}
     list_editable = ['status']
     list_display = ('title', 'author', 'status', 'modified', 'published',)
     list_filter = ('author', 'status', 'channel', 'created', 'modified',
-        'published',)
+        'published', ListFilter)
     readonly_fields = ['created', 'modified', 'time_diff']
     ordering = ('title', '-id',)
+    fieldsets = [('Fielset', {
+        'fields': ['created', ('slug', 'title', 'author', 'status')]}),
+    ]
+    date_hierarchy = 'created'
 
     search_fields = ['title', 'text']
 
@@ -28,7 +45,26 @@ class PostAdmin(admin.ModelAdmin):
         return super(PostAdmin, self).formfield_for_foreignkey(db_field,
             request, **kwargs)
 
+
+class FailPostAdmin(admin.ModelAdmin):
+    search_fields = ['nonexistent_field']
+    list_display = ['nonexistent_field']
+
+
+class ForbiddenPostAdmin(admin.ModelAdmin):
+    def has_add_permission(self, request):
+        False
+
+    def has_change_permission(self, request, obj=None):
+        False
+
+    def has_delete_permission(self, request):
+        False
+
+
 admin.site.register(Post, PostAdmin)
+admin.site.register(FailPost, FailPostAdmin)
+admin.site.register(ForbiddenPost, ForbiddenPostAdmin)
 
 
 admin.site.register(HasPrimarySlug)

--- a/test_project/main/models.py
+++ b/test_project/main/models.py
@@ -83,6 +83,14 @@ class Post(_Abstract):
         return reverse('post-detail', kwargs={'pk': self.pk})
 
 
+class ForbiddenPost(Post):
+    pass
+
+
+class FailPost(Post):
+    pass
+
+
 class HasPrimarySlug(models.Model):
     slug = models.SlugField(primary_key=True)
     title = models.CharField(max_length=140, unique=True)

--- a/test_project/main/models.py
+++ b/test_project/main/models.py
@@ -1,10 +1,10 @@
 import uuid
 
 # Django imports
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils import timezone
-from django.conf import settings
 
 
 class _Abstract(models.Model):

--- a/test_project/main/tests.py
+++ b/test_project/main/tests.py
@@ -35,15 +35,3 @@ class FailAdminSiteSmokeTest(AdminSiteSmokeTestMixin, TestCase):
 class ForbiddenAdminSiteSmokeTest(AdminSiteSmokeTestMixin, TestCase):
     fixtures = []
     exclude_modeladmins = [FailPostAdmin, PostAdmin, ChannelAdmin]
-
-    @for_all_model_admins
-    def test_changelist_view_search(self, model, model_admin):
-        with self.assertRaises(ModelAdminCheckException):
-            super(ForbiddenAdminSiteSmokeTest, self).\
-                test_changelist_view_search()
-
-    if django.VERSION >= (1, 8):
-        @for_all_model_admins
-        def test_changelist_view(self, model, model_admin):
-            with self.assertRaises(ModelAdminCheckException):
-                super(ForbiddenAdminSiteSmokeTest, self).test_changelist_view()

--- a/test_project/main/tests.py
+++ b/test_project/main/tests.py
@@ -1,0 +1,48 @@
+from .admin import FailPostAdmin, ForbiddenPostAdmin, PostAdmin, ChannelAdmin
+from django.test import TestCase
+from django_admin_smoke_tests.tests import AdminSiteSmokeTestMixin,\
+    ModelAdminCheckException, for_all_model_admins
+
+
+class AdminSiteSmokeTest(AdminSiteSmokeTestMixin, TestCase):
+    fixtures = []
+    exclude_apps = ['auth']
+    exclude_modeladmins = [FailPostAdmin, ForbiddenPostAdmin]
+
+
+class FailAdminSiteSmokeTest(AdminSiteSmokeTestMixin, TestCase):
+    fixtures = []
+    exclude_modeladmins = [ForbiddenPostAdmin, PostAdmin, ChannelAdmin]
+
+    @for_all_model_admins
+    def test_specified_fields(self, model, model_admin):
+        with self.assertRaises(ModelAdminCheckException):
+            super().test_specified_fields()
+
+    @for_all_model_admins
+    def test_changelist_view_search(self, model, model_admin):
+        with self.assertRaises(ModelAdminCheckException):
+            super().test_changelist_view_search()
+
+    if django.VERSION >= (1, 8):
+        @for_all_model_admins
+        def test_changelist_view(self, model, model_admin):
+            with self.assertRaises(ModelAdminCheckException):
+                super(FailAdminSiteSmokeTest, self).test_changelist_view()
+
+
+class ForbiddenAdminSiteSmokeTest(AdminSiteSmokeTestMixin, TestCase):
+    fixtures = []
+    exclude_modeladmins = [FailPostAdmin, PostAdmin, ChannelAdmin]
+
+    @for_all_model_admins
+    def test_changelist_view_search(self, model, model_admin):
+        with self.assertRaises(ModelAdminCheckException):
+            super(ForbiddenAdminSiteSmokeTest, self).\
+                test_changelist_view_search()
+
+    if django.VERSION >= (1, 8):
+        @for_all_model_admins
+        def test_changelist_view(self, model, model_admin):
+            with self.assertRaises(ModelAdminCheckException):
+                super(ForbiddenAdminSiteSmokeTest, self).test_changelist_view()

--- a/test_project/main/tests.py
+++ b/test_project/main/tests.py
@@ -1,8 +1,9 @@
-from .admin import FailPostAdmin, ForbiddenPostAdmin, PostAdmin, ChannelAdmin
+import django
+
 from django.test import TestCase
 from django_admin_smoke_tests.tests import AdminSiteSmokeTestMixin,\
     ModelAdminCheckException, for_all_model_admins
-import django
+from .admin import ChannelAdmin, FailPostAdmin, ForbiddenPostAdmin, PostAdmin
 
 
 class AdminSiteSmokeTest(AdminSiteSmokeTestMixin, TestCase):

--- a/test_project/main/tests.py
+++ b/test_project/main/tests.py
@@ -2,6 +2,7 @@ from .admin import FailPostAdmin, ForbiddenPostAdmin, PostAdmin, ChannelAdmin
 from django.test import TestCase
 from django_admin_smoke_tests.tests import AdminSiteSmokeTestMixin,\
     ModelAdminCheckException, for_all_model_admins
+import django
 
 
 class AdminSiteSmokeTest(AdminSiteSmokeTestMixin, TestCase):
@@ -17,12 +18,12 @@ class FailAdminSiteSmokeTest(AdminSiteSmokeTestMixin, TestCase):
     @for_all_model_admins
     def test_specified_fields(self, model, model_admin):
         with self.assertRaises(ModelAdminCheckException):
-            super().test_specified_fields()
+            super(FailAdminSiteSmokeTest, self).test_specified_fields()
 
     @for_all_model_admins
     def test_changelist_view_search(self, model, model_admin):
         with self.assertRaises(ModelAdminCheckException):
-            super().test_changelist_view_search()
+            super(FailAdminSiteSmokeTest, self).test_changelist_view_search()
 
     if django.VERSION >= (1, 8):
         @for_all_model_admins

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -92,7 +92,7 @@ USE_I18N = True
 
 USE_L10N = True
 
-USE_TZ = True
+USE_TZ = False
 
 
 # Static files (CSS, JavaScript, Images)

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -92,7 +92,7 @@ USE_I18N = True
 
 USE_L10N = True
 
-USE_TZ = False
+USE_TZ = True
 
 
 # Static files (CSS, JavaScript, Images)

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -22,7 +22,24 @@ SECRET_KEY = 'f8fkupu8pa%%u$wgk6c!os39el41v7i7^u*8xf#g5p@+c&)b#^'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-TEMPLATE_DEBUG = True
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'debug': True,
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
 
 ALLOWED_HOSTS = []
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     py{35,27}-dj110,
     py{35,27}-dj19,
     py{35,27}-dj18,
-    py{35,27}-dj17,
+    py{34,27}-dj17,
     py27-flake8,
 skipsdist=True
 
@@ -19,6 +19,7 @@ commands =
 basepython =
     py27: python2.7
     py35: python3.5
+    py34: python3.4
 deps =
     dj17: Django>=1.7,<1.8
     dj18: Django>=1.8,<1.9

--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,6 @@ test-executable =
     {envbindir}/python -Wall {envbindir}/coverage run --append --source=django_admin_smoke_tests
 commands =
     dj{17,18,19,110,dev}: {[testenv]test-executable} setup.py test
-
-    flake8: {envbindir}/flake8 --ignore=E128 --max-complexity 10 .
 basepython =
     py27: python2.7
     py35: python3.5
@@ -30,4 +28,9 @@ deps =
     dj{17,18,19,110,dev}: coverage
     dj{17,18,19,110,dev}: ipdb
 
-    flake8: flake8
+[testenv:py27-flake8]
+deps =
+    flake8
+    flake8-import-order
+commands =
+    {envbindir}/flake8 --ignore=E128 --max-complexity 10 .

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ deps =
     djdev: https://github.com/django/django/archive/master.tar.gz
     dj{17,18,19,110,dev}: coverage
     dj{17,18,19,110,dev}: ipdb
+    dj{17,18,19,110,dev}: pytz
 
 [testenv:py27-flake8]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ skipsdist=True
 [testenv]
 usedevelop=True
 test-executable = 
+    python --version
     {envbindir}/python -Wall {envbindir}/coverage run --append --source=django_admin_smoke_tests
 commands =
     dj{17,18,19,110,dev}: {[testenv]test-executable} setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
     py{35,27}-djdev,
+    py{35,27}-dj110,
     py{35,27}-dj19,
     py{35,27}-dj18,
     py{35,27}-dj17,
@@ -10,9 +11,9 @@ skipsdist=True
 [testenv]
 usedevelop=True
 test-executable = 
-    {envbindir}/coverage run --append --source=django_admin_smoke_tests 
+    {envbindir}/python -Wall {envbindir}/coverage run --append --source=django_admin_smoke_tests
 commands =
-    dj{17,18,19,dev}: {[testenv]test-executable} setup.py test
+    dj{17,18,19,110,dev}: {[testenv]test-executable} setup.py test
 
     flake8: {envbindir}/flake8 --ignore=E128 --max-complexity 10 .
 basepython =
@@ -22,8 +23,9 @@ deps =
     dj17: Django>=1.7,<1.8
     dj18: Django>=1.8,<1.9
     dj19: Django>=1.9,<1.10
+    dj110: Django>=1.10,<1.11
     djdev: https://github.com/django/django/archive/master.tar.gz
-    dj{17,18,19,dev}: coverage
-    dj{17,18,19,dev}: ipdb
+    dj{17,18,19,110,dev}: coverage
+    dj{17,18,19,110,dev}: ipdb
 
     flake8: flake8

--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,8 @@ commands =
     dj{17,18,19,110,dev}: {[testenv]test-executable} setup.py test
 basepython =
     py27: python2.7
-    py35: python3.5
     py34: python3.4
+    py35: python3.5
 deps =
     dj17: Django>=1.7,<1.8
     dj18: Django>=1.8,<1.9


### PR DESCRIPTION
This PR include all three previously closed PRs. It includes following improvements:
-compatibility fixes with Django 1.10
-stronger tests
-higher test coverage and higher range of versions tested in Travis
-exclude_modeladmins option
-more detailed exception message
