### PR TITLE
change 'test_specified_fields' to check for reverse_accessor fields

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,14 @@
-========================
-django-admin-smoke-tests
-========================
+=========================
+django-admin-smoke-tests-2
+=========================
+
+Fork of ``django-admin-smoke-tests``
+
+
+Installation
+------------
+
+``pip install django-admin-smoke-tests-2``
 
 .. image:: https://travis-ci.org/greyside/django-admin-smoke-tests.svg?branch=master
     :target: https://travis-ci.org/greyside/django-admin-smoke-tests
@@ -41,3 +49,4 @@ And you can exclude certain (external) apps or model admins with::
 
     exclude_apps = ['constance',]
     exclude_modeladmins = [apps.admin.ModelAdmin]
+

--- a/django_admin_smoke_tests/__init__.py
+++ b/django_admin_smoke_tests/__init__.py
@@ -3,6 +3,6 @@
 #
 # Licensed under a BSD 3-Clause License. See LICENSE file.
 
-VERSION = (0, 3, 0)
+VERSION = (0, 3, 1)
 
 __version__ = "".join([".".join(map(str, VERSION[0:3])), "".join(VERSION[3:])])

--- a/django_admin_smoke_tests/tests.py
+++ b/django_admin_smoke_tests/tests.py
@@ -57,7 +57,6 @@ class AdminSiteSmokeTestMixin(object):
     modeladmins = None
     exclude_apps = []
     exclude_modeladmins = []
-    fixtures = ['django_admin_smoke_tests']
 
     single_attributes = ['date_hierarchy']
     iter_attributes = [

--- a/django_admin_smoke_tests/tests.py
+++ b/django_admin_smoke_tests/tests.py
@@ -181,6 +181,7 @@ class AdminSiteSmokeTestMixin(object):
             has_form_field = attr in form_field_names
             has_model_class_attr = hasattr(model_instance.__class__, attr)
             has_admin_attr = hasattr(model_admin, attr)
+            has_reverse_accessor = hasattr(model_instance, attr + '_set')
 
             try:
                 has_model_attr = hasattr(model_instance, attr)
@@ -188,7 +189,8 @@ class AdminSiteSmokeTestMixin(object):
                 has_model_attr = attr in model_instance.__dict__
 
             has_field_or_attr = has_model_field or has_form_field or\
-                has_model_attr or has_admin_attr or has_model_class_attr
+                has_model_attr or has_admin_attr or has_model_class_attr\
+                or has_reverse_accessor
 
             self.assertTrue(has_field_or_attr, '%s not found on %s (%s)' %
                 (attr, model, model_admin,))

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,0 +1,23 @@
+from fabric.api import task
+from fabric.operations import local
+
+import utils_plus
+
+
+@task
+def release():
+    local('git push')
+    local('git tag {}'.format(utils_plus.__version__))
+    local('git push --tags')
+
+    # dont forget to have this file
+    # ~/.pypirc
+    # [distutils]
+    # index-servers =
+    #  pypi
+
+    # [pypi]
+    # repository: https://upload.pypi.org/legacy/
+    # username: jnoortheen
+    # password: pwd
+    local('python setup.py sdist upload')

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,23 +1,13 @@
 from fabric.api import task
 from fabric.operations import local
 
-import utils_plus
+import django_admin_smoke_tests
 
 
 @task
 def release():
     local('git push')
-    local('git tag {}'.format(utils_plus.__version__))
+    local('git tag {}'.format(django_admin_smoke_tests.__version__))
     local('git push --tags')
 
-    # dont forget to have this file
-    # ~/.pypirc
-    # [distutils]
-    # index-servers =
-    #  pypi
-
-    # [pypi]
-    # repository: https://upload.pypi.org/legacy/
-    # username: jnoortheen
-    # password: pwd
     local('python setup.py sdist upload')

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def runtests():
 
 
 setup(
-    name='django-admin-smoke-tests',
+    name='django-admin-smoke-tests-2',
     version=django_admin_smoke_tests.__version__,
     description="Runs some quick tests on your admin site objects to make sure \
 there aren't non-existant fields listed, etc.",


### PR DESCRIPTION
in my case, I has reverse accessor field in the `search_fields` attribute of the ModelAdmin. But the test_specified_fields method is not checking that fields. I've added that checks.