### PR TITLE
Add feat check reverse accessors

### DIFF
--- a/django_admin_smoke_tests/tests.py
+++ b/django_admin_smoke_tests/tests.py
@@ -57,7 +57,6 @@ class AdminSiteSmokeTestMixin(object):
     modeladmins = None
     exclude_apps = []
     exclude_modeladmins = []
-    fixtures = ['django_admin_smoke_tests']
 
     single_attributes = ['date_hierarchy']
     iter_attributes = [

--- a/django_admin_smoke_tests/tests.py
+++ b/django_admin_smoke_tests/tests.py
@@ -181,6 +181,7 @@ class AdminSiteSmokeTestMixin(object):
             has_form_field = attr in form_field_names
             has_model_class_attr = hasattr(model_instance.__class__, attr)
             has_admin_attr = hasattr(model_admin, attr)
+            has_reverse_accessor = hasattr(model_instance, attr + '_set')
 
             try:
                 has_model_attr = hasattr(model_instance, attr)
@@ -188,7 +189,8 @@ class AdminSiteSmokeTestMixin(object):
                 has_model_attr = attr in model_instance.__dict__
 
             has_field_or_attr = has_model_field or has_form_field or\
-                has_model_attr or has_admin_attr or has_model_class_attr
+                has_model_attr or has_admin_attr or has_model_class_attr\
+                or has_reverse_accessor
 
             self.assertTrue(has_field_or_attr, '%s not found on %s (%s)' %
                 (attr, model, model_admin,))


### PR DESCRIPTION
in my case, I has reverse accessor field in the search_fields attribute of the ModelAdmin. But the test_specified_fields method is not checking that fields. I've added that checks.

also closes #9 
